### PR TITLE
Bring back Taiwan to culture related strings.

### DIFF
--- a/System/compmod/system/componentmodel/CultureInfoConverter.cs
+++ b/System/compmod/system/componentmodel/CultureInfoConverter.cs
@@ -370,7 +370,7 @@ namespace System.ComponentModel {
                     {"Chinese (People's Republic of China)", "zh-CN"},
                     {"Chinese (Simplified)", "zh-CHS"},
                     {"Chinese (Singapore)", "zh-SG"},
-                    {"Chinese (----)", "zh-TW"},
+                    {"Chinese (Taiwan)", "zh-TW"},
                     {"Chinese (Traditional)", "zh-CHT"},
                     {"Corsican (France)", "co-FR"},
                     {"Croatian", "hr"},

--- a/mscorlib/system/globalization/regioninfo.cs
+++ b/mscorlib/system/globalization/regioninfo.cs
@@ -298,7 +298,7 @@ namespace System.Globalization {
             0x1C01, /* 97 */  // TN          ar-TN      Arabic (Tunisia)
             0x041F, /* 98 */  // TR          tr-TR      Turkish (Turkey)
             0x2C09, /* 99 */  // TT          en-TT      English (Trinidad and Tobago)
-            0x0404, /*100 */  // TW          zh-TW      Chinese (----)
+            0x0404, /*100 */  // TW          zh-TW      Chinese (Taiwan)
             0x0422, /*101 */  // UA          uk-UA      Ukrainian (Ukraine)
             0x0409, /*102 */  // US          en-US      English (United States)
             0x380A, /*103 */  // UY          es-UY      Spanish (Uruguay)


### PR DESCRIPTION
There seems to be some word filterings that hid "Taiwan" in the sources. At least there was one string resource that brought code change, not just code comment.
