### PR TITLE
Expand usage of the DisplayNameAttribute to the elements of enums.

### DIFF
--- a/System/compmod/system/componentmodel/DisplayNameAttribute.cs
+++ b/System/compmod/system/componentmodel/DisplayNameAttribute.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel {
     ///    <para>Specifies the display name for a property or event.  The default is the name of the property or event.</para>
     /// </devdoc>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes")]    
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Event | AttributeTargets.Class | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Event | AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Field)]
     public class DisplayNameAttribute : Attribute {
         /// <devdoc>
         /// <para>Specifies the default value for the <see cref='System.ComponentModel.DisplayNameAttribute'/> , which is an


### PR DESCRIPTION
Now in PropertyGrid can display more friendly names for enums.
```cs
    public enum Axises
    {
        [DisplayName("Ось X")]
        X,
        [DisplayName("Ось Y")]
        Y,
        [DisplayName("Ось Z")]
        Z,
        [DisplayName("Произвольный вектор")]
        CustomVector,
    }
```
Example:
![displayname](https://cloud.githubusercontent.com/assets/16261478/11998267/a4cd59fa-aaa7-11e5-9244-2211fe17e6bb.png)
