### PR TITLE
Bug: Incorrect file pattern matching due to typo

### DIFF
--- a/System/services/io/system/io/PatternMatcher.cs
+++ b/System/services/io/system/io/PatternMatcher.cs
@@ -20,8 +20,8 @@ namespace System.IO {
         ///     Private constants (directly from C header files)
         /// </devdoc>
         private const int MATCHES_ARRAY_SIZE = 16;
-        private const char ANSI_DOS_STAR = '>';
-        private const char ANSI_DOS_QM = '<';
+        private const char ANSI_DOS_STAR = '<';
+        private const char ANSI_DOS_QM = '>';
         private const char DOS_DOT = '"';
         
         /// <devdoc>

--- a/mscorlib/system/io/path.cs
+++ b/mscorlib/system/io/path.cs
@@ -72,15 +72,17 @@ namespace System.IO {
         // See the "Naming a File" MSDN conceptual docs for more details on
         // what is valid in a file name (which is slightly different from what
         // is legal in a path name).
+        // Exclude wildcards per FsRtllsNameInExpression: .?*"><
         // Note: This list is duplicated in CheckInvalidPathChars
         [Obsolete("Please use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
-        public static readonly char[] InvalidPathChars = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
+        public static readonly char[] InvalidPathChars = { '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
 
         // Trim trailing white spaces, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.
         // String.WhitespaceChars will trim aggressively than what the underlying FS does (for ex, NTFS, FAT).    
         internal static readonly char[] TrimEndChars = { (char) 0x9, (char) 0xA, (char) 0xB, (char) 0xC, (char) 0xD, (char) 0x20,   (char) 0x85, (char) 0xA0};
         
-        private static readonly char[] RealInvalidPathChars = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
+        // Exclude wildcards per FsRtllsNameInExpression: .?*"><
+        private static readonly char[] RealInvalidPathChars = { '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
 
         // This is used by HasIllegalCharacters
         private static readonly char[] InvalidPathCharsWithAdditionalChecks = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31, '*', '?' };


### PR DESCRIPTION
Per `ntifs.h`, `ANSI_DOS_STAR` and `ANSI_DOS_QM` are reversed.  Star should be `<` and quotation mark should be `>`, but it's currently the opposite.  See [FsRtllsNameInExpression](https://msdn.microsoft.com/en-us/library/windows/hardware/ff546850.aspx) and `ntifs.h`.

There's a longer commentary on this matter over at [Stack Overflow](http://stackoverflow.com/a/17739503/1188377).