### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+# READ BEFORE FILING
+
+Do not file issues regarding functionality of the .NET Framework. This repo
+only tracks infrastructure issues regarding the following items:
+
+* Missing or outdated source in this repository
+* Reference Source Browser (http://referencesource.microsoft.com/)
+* Debugging the .NET Framework using Reference Source
+
+For issues regarding functionality, please use the following resources:
+
+* BCL. https://github.com/dotnet/corefx
+* ASP.NET. https://github.com/aspnet/home
+* Everything else. https://connect.microsoft.com/VisualStudio/feedback/LoadSubmitFeedbackForm


### PR DESCRIPTION
We'd like to re-enable filing issues in this repository. We've originally disabled it because people filed bugs against the .NET Framework which this repo doesn't track. This issue template makes this clear and also provides pointers where issues should be filed.

@richlander @preetikr @tarekgh