### PR TITLE
No need to double check the same condition

### DIFF
--- a/mscorlib/system/collections/generic/list.cs
+++ b/mscorlib/system/collections/generic/list.cs
@@ -795,9 +795,6 @@ namespace System.Collections.Generic {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
             }
 
-            if ((Count !=0) && (count < 0)) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-            }
             Contract.Ensures(Contract.Result<int>() >= -1);
             Contract.Ensures(((Count == 0) && (Contract.Result<int>() == -1)) || ((Count > 0) && (Contract.Result<int>() <= index)));
             Contract.EndContractBlock();


### PR DESCRIPTION
Currently, it's checking twice for exactly the same condition. Which is redundant and unnecessary.