### PR TITLE
Fix typo for the word acceptable

### DIFF
--- a/System.ServiceModel.Internals/System/Runtime/Collections/ValidatingCollection.cs
+++ b/System.ServiceModel.Internals/System/Runtime/Collections/ValidatingCollection.cs
@@ -7,7 +7,7 @@ namespace System.Runtime.Collections
     using System.Collections.ObjectModel;
  
     // simple helper class to allow passing in a func that performs validations of
-    // acceptible values
+    // acceptable values
     class ValidatingCollection<T> : Collection<T>
     {
         public ValidatingCollection()


### PR DESCRIPTION
This is the bot fixing typos of misspelled word, here the word is acceptable which is used as acceptible