### PR TITLE
ArgumentNullException prevented when _session.StaticObjects is null

### DIFF
--- a/System.Web/Abstractions/HttpSessionStateWrapper.cs
+++ b/System.Web/Abstractions/HttpSessionStateWrapper.cs
@@ -92,8 +92,8 @@ namespace System.Web {
 
         public override HttpStaticObjectsCollectionBase StaticObjects {
             get {
-                // method returns an empty collection rather than null
-                return new HttpStaticObjectsCollectionWrapper(_session.StaticObjects);
+                // HttpStaticObjectsCollectionWrapper will throw ArgumentNullException if _session.StaticObjects is null
+                return new HttpStaticObjectsCollectionWrapper(_session.StaticObjects ?? new HttpStaticObjectsCollection());
             }
         }
 


### PR DESCRIPTION
Constructor of the HttpStaticObjectsCollectionWrapper throws ArgumentNullException if the parameter is null. (Even though the previous comment was telling that it will return an empty collection).

This fix will prevent the exception and also will return an empty collection when _session.StaticObjects is null.