### PR TITLE
Fix spacing in Array.Copy method call in queue.cs

### DIFF
--- a/mscorlib/system/collections/queue.cs
+++ b/mscorlib/system/collections/queue.cs
@@ -153,7 +153,7 @@ namespace System.Collections {
             Array.Copy(_array, _head, array, index, firstPart);
             numToCopy -= firstPart;
             if (numToCopy > 0)
-                Array.Copy(_array, 0, array, index+_array.Length - _head, numToCopy);
+                Array.Copy(_array, 0, array, index + _array.Length - _head, numToCopy);
         }
         
         // Adds obj to the tail of the queue.


### PR DESCRIPTION
Fixed spacing in the Array.Copy method call to improve readability and consistency with the surrounding code.

# READ BEFORE FILING

This repository is read-only and doesn't accept community pull requests.